### PR TITLE
MAUI-825489-Updated chart nuget file

### DIFF
--- a/ThermalMaterialErrorBarSample/ThermalMaterialErrorBarSample/ThermalMaterialErrorBarSample.csproj
+++ b/ThermalMaterialErrorBarSample/ThermalMaterialErrorBarSample/ThermalMaterialErrorBarSample.csproj
@@ -53,7 +53,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Syncfusion.Maui.Charts" Version="*" />
+	  <PackageReference Include="Syncfusion.Maui.Charts" Version="23.1.38" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description
If  encounter the 'NuGet not loaded' issue when downloading the sample, remove the NuGet package and then reinstall it to ensure that the chart sample runs successfully.
![image](https://github.com/SyncfusionExamples/Creating-an-Error-Bar-Chart-for-Exploring-the-Thermal-Expansion-of-Materials/assets/102796134/f5251cce-d63a-4203-ae34-387f48a0d70c)
